### PR TITLE
fix(Web/js/sprite.js): Error getting image data for sprite : firefox

### DIFF
--- a/Web/js/sprite.js
+++ b/Web/js/sprite.js
@@ -28,6 +28,8 @@ define(['jquery', 'animation', 'sprites'], function($, Animation, sprites) {
 
         	this.image = new Image();
         	this.image.src = this.filepath;
+			this.image.width = this.width;
+			this.image.height = this.height;
 
         	this.image.onload = function() {
         		self.isLoaded = true;


### PR DESCRIPTION
"Error getting image data for sprite : firefox" occurred due to missing this.image.width and this.image.height properties.


![屏幕截图 2025-05-18 185404](https://github.com/user-attachments/assets/737aae72-3d09-445a-98b2-f34bdeb4a49c)
